### PR TITLE
enhance(Implemented caching in transactions)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
 			<version>2.0.1</version>
 		</dependency>
 		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast</artifactId>
+			<version>5.5.0</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.firebase</groupId>
 			<artifactId>firebase-admin</artifactId>
 			<version>9.4.3</version>

--- a/src/main/kotlin/com/nbk/insights/InsightsApplication.kt
+++ b/src/main/kotlin/com/nbk/insights/InsightsApplication.kt
@@ -1,11 +1,22 @@
 package com.nbk.insights
 
+import com.hazelcast.core.Hazelcast
+import com.hazelcast.config.Config
+import com.hazelcast.core.HazelcastInstance
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+
 
 @SpringBootApplication
 class InsightsApplication
 
 fun main(args: Array<String>) {
 	runApplication<InsightsApplication>(*args)
+	insightsCacheConfig.getMapConfig("transactions-user").setTimeToLiveSeconds(360)
+	insightsCacheConfig.getMapConfig("transactions-account").setTimeToLiveSeconds(360)
+
+
 }
+
+val insightsCacheConfig = Config("insights-cache")
+val serverInsightsCache: HazelcastInstance = Hazelcast.newHazelcastInstance(insightsCacheConfig)

--- a/src/main/kotlin/com/nbk/insights/helper/TransactionsHelpers.kt
+++ b/src/main/kotlin/com/nbk/insights/helper/TransactionsHelpers.kt
@@ -1,0 +1,19 @@
+package com.nbk.insights.helper
+
+fun buildCacheKey(
+    accountId: Long?,
+    category: String?,
+    mccId: Long?,
+    period: String,
+    year: Int?,
+    month: Int?
+): String {
+    return listOfNotNull(
+        "account: $accountId",
+        "category: ${category ?: "any"}",
+        "mcc: ${mccId ?: "any"}",
+        "period: $period",
+        "year: ${year ?: "any"}",
+        "month: ${month ?: "any"}"
+    ).joinToString(" | ")
+}


### PR DESCRIPTION
Transaction queries are cached using Hazelcast, synchronizing the cache across all running instances of the application. We cache transaction queries at both user and account levels, using composite keys to account for different filters. Since there is no trigger for immediate cache invalidation when the database changes (such as POST event), cached entries are invalidated by a time-to-live (TTL) setting of 6 minutes. This means that new or updated transactions may not appear in cached responses immediately, but will be visible once the cache expires and is refreshed with the latest data from the database.